### PR TITLE
Remove hadoop-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
 			<version>3.0.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
-			<version>2.2.0</version>
-		</dependency>
-		<dependency>
 			<groupId>de.jungblut.common</groupId>
 			<artifactId>thomasjungblut-common</artifactId>
 			<version>1.0</version>

--- a/src/de/jungblut/glove/impl/GloveBinaryRandomAccessReader.java
+++ b/src/de/jungblut/glove/impl/GloveBinaryRandomAccessReader.java
@@ -13,9 +13,8 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Path;
 
-import org.apache.hadoop.io.WritableUtils;
-
 import de.jungblut.glove.GloveRandomAccessReader;
+import de.jungblut.glove.util.WritableUtils;
 import de.jungblut.math.DoubleVector;
 import de.jungblut.math.dense.DenseDoubleVector;
 

--- a/src/de/jungblut/glove/impl/GloveBinaryReader.java
+++ b/src/de/jungblut/glove/impl/GloveBinaryReader.java
@@ -13,14 +13,13 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.hadoop.io.IOUtils;
-import org.apache.hadoop.io.WritableUtils;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
 
 import de.jungblut.glove.GloveStreamReader;
+import de.jungblut.glove.util.IOUtils;
 import de.jungblut.glove.util.StringVectorPair;
+import de.jungblut.glove.util.WritableUtils;
 import de.jungblut.math.DoubleVector;
 import de.jungblut.math.dense.DenseDoubleVector;
 
@@ -44,9 +43,7 @@ public class GloveBinaryReader implements GloveStreamReader {
         .stream(Spliterators.spliteratorUnknownSize(filesIterator,
             Spliterator.ORDERED), false);
 
-    stream.onClose(() -> {
-      IOUtils.closeStream(filesIterator);
-    });
+    stream.onClose(() -> IOUtils.cleanup(filesIterator));
 
     return stream;
   }
@@ -141,8 +138,7 @@ public class GloveBinaryReader implements GloveStreamReader {
 
     @Override
     public void close() throws IOException {
-      IOUtils.closeStream(dict);
-      IOUtils.closeStream(vec);
+      IOUtils.cleanup(dict, vec);
     }
 
   }

--- a/src/de/jungblut/glove/impl/GloveBinaryWriter.java
+++ b/src/de/jungblut/glove/impl/GloveBinaryWriter.java
@@ -11,12 +11,11 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import org.apache.hadoop.io.WritableUtils;
-
 import com.google.common.base.Preconditions;
 
 import de.jungblut.glove.GloveWriter;
 import de.jungblut.glove.util.StringVectorPair;
+import de.jungblut.glove.util.WritableUtils;
 import de.jungblut.math.DoubleVector;
 
 public class GloveBinaryWriter implements GloveWriter {

--- a/src/de/jungblut/glove/util/IOUtils.java
+++ b/src/de/jungblut/glove/util/IOUtils.java
@@ -1,0 +1,32 @@
+package de.jungblut.glove.util;
+
+import java.io.IOException;
+
+
+/**
+ * An utility class for I/O related functionality.
+ */
+/* Taken from org.apache.hadoop.commons and modified */
+public class IOUtils {
+
+
+  /**
+   * Close the Closeable objects and <b>ignore</b> any {@link IOException} or null pointers. Must
+   * only be used for cleanup in exception handlers.
+   *
+   * @param closeables the objects to close
+   */
+  public static void cleanup(java.io.Closeable... closeables) {
+    for (java.io.Closeable c : closeables) {
+      if (c != null) {
+        try {
+          c.close();
+        } catch (IOException e) {
+          System.err.println("Exception in closing " + c);
+          System.err.println(e.getMessage());
+        }
+      }
+    }
+  }
+
+}

--- a/src/de/jungblut/glove/util/WritableUtils.java
+++ b/src/de/jungblut/glove/util/WritableUtils.java
@@ -1,0 +1,100 @@
+package de.jungblut.glove.util;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/* Taken from org.apache.hadoop.commons and modified */
+public final class WritableUtils {
+
+  /**
+   * Serializes a long to a binary stream with zero-compressed encoding. For -112 <= i <= 127, only
+   * one byte is used with the actual value. For other values of i, the first byte value indicates
+   * whether the long is positive or negative, and the number of bytes that follow. If the first
+   * byte value v is between -113 and -120, the following long is positive, with number of bytes
+   * that follow are -(v+112). If the first byte value v is between -121 and -128, the following
+   * long is negative, with number of bytes that follow are -(v+120). Bytes are stored in the
+   * high-non-zero-byte-first order.
+   *
+   * @param stream Binary output stream
+   * @param i Long to be serialized
+   * @throws java.io.IOException
+   */
+  public static void writeVLong(DataOutput stream, long i) throws IOException {
+    if (i >= -112 && i <= 127) {
+      stream.writeByte((byte) i);
+      return;
+    }
+
+    int len = -112;
+    if (i < 0) {
+      i ^= -1L; // take one's complement'
+      len = -120;
+    }
+
+    long tmp = i;
+    while (tmp != 0) {
+      tmp = tmp >> 8;
+      len--;
+    }
+
+    stream.writeByte((byte) len);
+
+    len = len < -120 ? -(len + 120) : -(len + 112);
+
+    for (int idx = len; idx != 0; idx--) {
+      int shiftbits = (idx - 1) * 8;
+      long mask = 0xFFL << shiftbits;
+      stream.writeByte((byte) ((i & mask) >> shiftbits));
+    }
+  }
+
+  /**
+   * Reads a zero-compressed encoded long from input stream and returns it.
+   *
+   * @param stream Binary input stream
+   * @throws java.io.IOException
+   * @return deserialized long from stream.
+   */
+  public static long readVLong(DataInput stream) throws IOException {
+    byte firstByte = stream.readByte();
+    int len = decodeVIntSize(firstByte);
+    if (len == 1) {
+      return firstByte;
+    }
+    long i = 0;
+    for (int idx = 0; idx < len - 1; idx++) {
+      byte b = stream.readByte();
+      i = i << 8;
+      i = i | b & 0xFF;
+    }
+    return isNegativeVInt(firstByte) ? i ^ -1L : i;
+  }
+
+  /**
+   * Parse the first byte of a vint/vlong to determine the number of bytes
+   *
+   * @param value the first byte of the vint/vlong
+   * @return the total number of bytes (1 to 9)
+   */
+  public static int decodeVIntSize(byte value) {
+    if (value >= -112) {
+      return 1;
+    } else if (value < -120) {
+      return -119 - value;
+    }
+    return -111 - value;
+  }
+
+  /**
+   * Given the first byte of a vint/vlong, determine the sign
+   *
+   * @param value the first byte
+   * @return is the value negative
+   */
+  public static boolean isNegativeVInt(byte value) {
+    return value < -120 || value >= -112 && value < 0;
+  }
+
+
+}

--- a/test/de/jungblut/glove/impl/GloveBinaryReaderWriterTest.java
+++ b/test/de/jungblut/glove/impl/GloveBinaryReaderWriterTest.java
@@ -9,11 +9,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.io.WritableUtils;
 import org.junit.Test;
 
 import de.jungblut.glove.GloveTestUtils;
 import de.jungblut.glove.util.StringVectorPair;
+import de.jungblut.glove.util.WritableUtils;
 
 public class GloveBinaryReaderWriterTest {
 


### PR DESCRIPTION
There are only a couple of methods used so replicated and removed the dependency. 
hadoop-common is a large dependency which pulls in a lot of other dependencies these (such as javax.servlet) can cause version issue when using the library.   